### PR TITLE
Remove has_rdoc from gemspec

### DIFF
--- a/turbo-sprockets-rails4.gemspec
+++ b/turbo-sprockets-rails4.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.description = s.summary = 'Speed up asset precompliation by compiling assets in parallel.'
 
   s.platform = Gem::Platform::RUBY
-  s.has_rdoc = true
 
   s.add_dependency 'parallel', '~> 1.10'
   s.add_dependency 'railties', '>= 4'


### PR DESCRIPTION
> NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.